### PR TITLE
Customer Link response handler updated to account for multiple formats.

### DIFF
--- a/lib/CustomerLink.php
+++ b/lib/CustomerLink.php
@@ -112,15 +112,24 @@ class CustomerLink extends Core {
     if ($result['STATUS'] == 'Failure') {
       return $result['ERRORS'];
     }
+
+    $authresult = FALSE;
+
     // Handle reject codes.
-    else {
+    if (isset($result['PROCESSRESULT'])) {
       $authresult = $result['PROCESSRESULT']['AUTHORIZATIONRESULT'];
-      // Process reject codes.
-      if (strpos($authresult, 'Error') !== FALSE) {
-        return $authresult;
-      }
     }
-    return $result;
+    else if (isset($result['CUSTOMERS']))
+    {
+      $authresult = $result['CUSTOMERS'];
+    }
+
+    if (!$authresult)
+    {
+      $authresult = $result;
+    }
+
+    return $authresult;
   }
 
 }


### PR DESCRIPTION
iATS API may respond with either a PROCESSRESULT object or a CUSTOMERS object, depending on the outcome of the request. This change updates the Customer Link response handler to account for that.
