### PR TITLE
Canadian dollars now represented as CAD, not CDN.

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -266,7 +266,7 @@ class Core {
           'VISA','MC', 'AMX', 'DSC',
           'VISA DEBIT', 'MC DEBIT',
         ),
-        'CDN' => array(
+        'CAD' => array(
           'VISA', 'MC', 'AMX',
           'VISA DEBIT',
         ),


### PR DESCRIPTION
As identified in issue #15, CAD is the correct representation of Canadian dollars, not CDN.

This is consistent with the [iATS API docs](http://home.iatspayments.com/sites/default/files/iats_webservices_processlink_version_4.0.pdf) section 1.4.3.
