### PR TITLE
fix errors in unit tests and mark tests as skipped

### DIFF
--- a/Tests/CustomerLinkTest.php
+++ b/Tests/CustomerLinkTest.php
@@ -138,7 +138,7 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
   public function testCustomerLinkupdateCreditCardCustomerCodeNewRecurringSchedule() {
     $iats = new CustomerLink(self::$agentCode, self::$password, 'NA');
 
-    $beginTime = mktime(0, 0, 0, date('n'), date('j') + 1, date('Y'));
+    $beginTime = strtotime('+1 day');
     $endTime = mktime(0, 0, 0, date('n'), date('j'), date('Y') + 10);
 
     // Create and populate the request object.
@@ -197,7 +197,7 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
   public function testCustomerLinkupdateCreditCardCustomerCodeNewRecurringScheduleDate() {
     $iats = new CustomerLink(self::$agentCode, self::$password, 'NA');
 
-    $beginTime = mktime(0, 0, 0, date('n'), date('j'), date('Y'));
+    $beginTime = strtotime('+1 day');
     $endTime = mktime(0, 0, 0, date('n'), date('j'), date('Y') + 10);
 
     // Create and populate the request object.
@@ -256,7 +256,7 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
   public function testCustomerLinkupdateCreditCardCustomerCodeNewRecurringScheduleCard() {
     $iats = new CustomerLink(self::$agentCode, self::$password, 'NA');
 
-    $beginTime = mktime(0, 0, 0, date('n'), date('j'), date('Y'));
+    $beginTime = strtotime('+1 day');
     $endTime = mktime(0, 0, 0, date('n'), date('j'), date('Y') + 10);
 
     // Create and populate the request object.
@@ -496,6 +496,8 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
       'zipCode' => '12345',
     );
 
+	$this->markTestSkipped('Test skipped because directDebitACHEFTPayerValidate is missing');
+
     $response = $iats->directDebitACHEFTPayerValidate($request);
 
     // API responded correctly.
@@ -544,6 +546,8 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
       'accountType' => 'CHECKING',
     );
 
+	$this->markTestSkipped('Test skipped because directDebitCreateACHEFTCustomerCode is missing');
+
     $response = $iats->directDebitCreateACHEFTCustomerCode($request);
 
     // API responded correctly.
@@ -591,6 +595,8 @@ class CustomerLinkTest extends \PHPUnit_Framework_TestCase {
       'accountType' => 'CHECKING',
       'updateAccountNum' => FALSE,
     );
+
+	$this->markTestSkipped('Test skipped because directDebitUpdateACHEFTCustomerCode is missing');
 
     $response = $iats->directDebitUpdateACHEFTCustomerCode($request);
 


### PR DESCRIPTION
Hi, everyone. I recently downloaded the iATS PHP wrapper and ran the unit tests. Unfortunately, there were a few fatal errors in the tests. Some tests are attempting to call functions in the wrapper that had been removed in the latest release. I don't know if those functions have been removed because they have been deprecated in the API or there is some other reason. So, to fix the errors in the unit tests, I just marked those specific ones as skipped.

Once I was able to get the full suite to run without fatal errors, I was seeing tests failing due to the variable for a beginning date in the test data. That variable is required to be set a day ahead for the particular API function being tested. I was able to fix those tests by changing that variable in the test data.

I'm creating this pull request just for the issues I addressed in the unit tests. I am still seeing failed tests, though, because data in the test account being tested against isn't the data the unit tests are expecting.